### PR TITLE
GCR-3237 Reset nearest ref and over-poly state in SetCenter

### DIFF
--- a/src/DotRecast.Detour/DtFindNearestPolyQuery.cs
+++ b/src/DotRecast.Detour/DtFindNearestPolyQuery.cs
@@ -30,6 +30,8 @@ namespace DotRecast.Detour
             _center = center;
             _nearestDistanceSqr = float.MaxValue;
             _nearestPoint = center;
+            _nearestRef = 0;
+            _overPoly = false;
         }
 
         public void Process(DtMeshTile tile, ReadOnlySpan<int> polys, ReadOnlySpan<long> refs, int count)


### PR DESCRIPTION
`SetCenter` was added on the fork so `DtFindNearestPolyQuery` can be reused without allocation (GGG-2831), but it only reset `_center`, `_nearestDistanceSqr`, and `_nearestPoint`. `_nearestRef` and `_overPoly` kept their values from the previous query, so when `QueryPolygons` finds no polygons (point outside the search box), `NearestRef()` silently returns the previous query''s polygon instead of 0.

In gg-game this poisons `DetourNavMesh.TryStartPath`: the start-poly lookup runs first, and an off-mesh destination then reuses the start poly as the end poly, producing a bogus valid path toward an unreachable point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)