### PR TITLE
Fix stacked off-mesh links collapsing in FindStraightPath

### DIFF
--- a/src/DotRecast.Detour/DtNavMeshQuery.cs
+++ b/src/DotRecast.Detour/DtNavMeshQuery.cs
@@ -1769,6 +1769,25 @@ namespace DotRecast.Detour
                         toType = DtPolyTypes.DT_POLYTYPE_GROUND;
                     }
 
+                    // [FIX] Two off-mesh connections sharing an exact endpoint (e.g. a two-stage parkour
+                    // climb whose first link's end == second link's start) collapse: the second link's start
+                    // produces no funnel turn, so it never gets a straight-path vertex and the link silently
+                    // becomes a walk segment. If the previously emitted vertex sits on this off-mesh link's
+                    // start but isn't flagged as a connection, promote it (AppendVertex merges onto it) so the
+                    // link is preserved. Only fires for the coincident case; normal links are unaffected.
+                    if (i + 1 < pathSize && toType == DtPolyTypes.DT_POLYTYPE_OFFMESH_CONNECTION
+                        && straightPathCount > 0
+                        && RcVec.Equal(straightPath[straightPathCount - 1].pos, left)
+                        && (straightPath[straightPathCount - 1].flags & DtStraightPathFlags.DT_STRAIGHTPATH_OFFMESH_CONNECTION) == 0)
+                    {
+                        stat = AppendVertex(left, DtStraightPathFlags.DT_STRAIGHTPATH_OFFMESH_CONNECTION, path[i + 1],
+                            straightPath, ref straightPathCount, maxStraightPath);
+                        if (!stat.InProgress())
+                        {
+                            return stat;
+                        }
+                    }
+
                     // Right vertex.
                     if (DtUtils.TriArea2D(portalApex, portalRight, right) <= 0.0f)
                     {


### PR DESCRIPTION
Two off-mesh connections sharing an exact endpoint (e.g. a two-stage parkour climb where link A.end == link B.start) collapse in FindStraightPath: B's start coincides with the funnel apex, so the degenerate portal narrows without an apex advance and B's OFFMESH flag is never emitted. The link's span is then followed as a plain walk segment and the agent stalls.

Fix: when entering an off-mesh connection whose start coincides with the previously emitted vertex (== apex with options=0), promote that vertex to the off-mesh connection via AppendVertex (merges onto it). Fires only for the coincident case; non-coincident links are unaffected.

Validated in gg-game: target climb route flips to pass; full route suite no regressions; full 17-map bot-battle suite no map regressed, total nav stalls 801->535 (cartel 169->50, logistic 160->40). Known limitation: handles a double-stack, not a triple-stack (none exist in content).